### PR TITLE
fix/input-file

### DIFF
--- a/helpdesk_client/v3/client.py
+++ b/helpdesk_client/v3/client.py
@@ -131,7 +131,7 @@ class HelpdeskClient:
         self,
         request_id: int,
         dto: UploadFileDTO,
-        file_field: Literal["file", "input_file"] = "file",
+        file_field: Literal["file", "input_file"] = "input_file",
     ) -> RequestAttachmentSchema:
         """
         Прикрепляет файл к заявке.
@@ -362,7 +362,7 @@ class SyncHelpdeskClient:
         self,
         request_id: int,
         dto: UploadFileDTO,
-        file_field: Literal["file", "input_file"] = "file",
+        file_field: Literal["file", "input_file"] = "input_file",
     ) -> RequestAttachmentSchema:
         """
         Прикрепляет файл к заявке.


### PR DESCRIPTION
In the method `attach_file_to_request`, the default value for `file_field` has been changed.


`file` -> `input_file`